### PR TITLE
Respect content before the first title

### DIFF
--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -2,7 +2,7 @@ module JekyllTitlesFromHeadings
   class Generator < Jekyll::Generator
     attr_accessor :site
 
-    TITLE_REGEX = %r!^\#{1,3} (.*)\n$!
+    TITLE_REGEX = %r!\A\s*\#{1,3} (.*)\n$!
     CONVERTER_CLASS = Jekyll::Converters::Markdown
 
     safe true

--- a/spec/fixtures/site/page-with-content-before-title.md
+++ b/spec/fixtures/site/page-with-content-before-title.md
@@ -1,0 +1,6 @@
+---
+---
+
+Something else
+
+# Title

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
   let(:page_with_h2) { page_by_path(site, "page-with-h2.md") }
   let(:page_with_h3) { page_by_path(site, "page-with-h3.md") }
   let(:page_with_empty_title) { page_by_path(site, "page-with-empty-title.md") }
+  let(:page_with_content_before_title) do
+    page_by_path(site, "page-with-content-before-title.md")
+  end
 
   subject { described_class.new(site) }
 
@@ -76,6 +79,10 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
 
     it "respects YAML titles" do
       expect(subject.title_for(page_with_title)).to eql("Page with title")
+    end
+
+    it "respects content before the title" do
+      expect(subject.title_for(page_with_content_before_title)).to be_nil
     end
   end
 


### PR DESCRIPTION
This PR makes the title detection more strict, such that the heading line must be the first non-whitespace line in the document, rather than looking for the first title it finds (even if there's other non-title content before it).