### PR TITLE
Fix typos in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jekyll Title from Headings
 
-*A Jekyll plugin to pull page the title from first Markdown heading when none is specified.*
+*A Jekyll plugin to pull the page title from the first Markdown heading when none is specified.*
 
 [![Build Status](https://travis-ci.org/benbalter/jekyll-title-from-headings.svg?branch=master)](https://travis-ci.org/benbalter/jekyll-title-from-headings)
 

--- a/jekyll-titles-from-headings.gemspec
+++ b/jekyll-titles-from-headings.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors       = ["Ben Balter"]
   s.email         = ["ben.balter@github.com"]
   s.homepage      = "https://github.com/benbalter/jekyll-titles-from-headings"
-  s.summary       = "A Jekyll plugin to pull page the title from fist Markdown heading when none is specified"
+  s.summary       = "A Jekyll plugin to pull the page title from the first Markdown heading when none is specified."
 
   s.files         = `git ls-files lib *.md`.split("\n")
   s.platform      = Gem::Platform::RUBY


### PR DESCRIPTION
Fixes a couple of overlooked typos.

---
Fixes #9 by @hobbsy
Ref: [Comment](https://github.com/benbalter/jekyll-titles-from-headings/pull/8/files#r93446170) by @TJScalzo
