### PR TITLE
Opt-in option to strip titles on a global and per-page basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,25 @@ Additionally, this allows you to store the title semantically, in the document i
   gems:
     - jekyll-titles-from-headings
   ```
+
+## Configuration
+If your theme renders titles based on `page.title`, you can remove the title from the content by by setting
+
+```yml
+strip_title: true
+```
+
+in your site's config file.
+
+To limit this behavior to a certain layouts or paths, use
+
+```yml
+defaults:
+  - scope:
+      path: <path-with-builtin-titles>
+      layout: <layout-with-builtin-title>
+    values:
+      strip_title: true
+```
+
+instead. For more on using front matter defaults, see the [Jekyll docs](https://jekyllrb.com/docs/configuration/#front-matter-defaults).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jekyll Title from Headings
+# Jekyll Titles from Headings
 
 *A Jekyll plugin to pull the page title from the first Markdown heading when none is specified.*
 
@@ -32,23 +32,25 @@ Additionally, this allows you to store the title semantically, in the document i
   ```
 
 ## Configuration
-If your theme renders titles based on `page.title`, you can remove the title from the content by by setting
+If your theme renders titles based on `page.title`, you can remove the title from the content by setting
 
 ```yml
-strip_title: true
+titles_from_headings:
+  strip_title: true
 ```
 
-in your site's config file.
+in your site's `_config.yml` to prevent rendering the title twice.
 
-To limit this behavior to a certain layouts or paths, use
+To limit this behavior to a certain layouts or paths, you can use [front matter defaults](https://jekyllrb.com/docs/configuration/#front-matter-defaults), e.g.
 
 ```yml
 defaults:
   - scope:
-      path: <path-with-builtin-titles>
-      layout: <layout-with-builtin-title>
+      path: some-path
+      layout: some_layout
+      type: posts # pages, posts, drafts or any collection in your site.
     values:
       strip_title: true
 ```
 
-instead. For more on using front matter defaults, see the [Jekyll docs](https://jekyllrb.com/docs/configuration/#front-matter-defaults).
+Note that you need [`jekyll-optional-front-matter`](https://github.com/benbalter/jekyll-optional-front-matter) for this to work on pages without a front matter.

--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -33,6 +33,7 @@ module JekyllTitlesFromHeadings
       site.pages.each do |document|
         next unless should_add_title?(document)
         document.data["title"] = title_for(document)
+        strip_title!(document) if strip_title?(document)
       end
     end
 
@@ -66,6 +67,18 @@ module JekyllTitlesFromHeadings
       STRIP_MARKUP_FILTERS.reduce(string) do |memo, method|
         filters.public_send(method, memo)
       end.gsub(EXTRA_MARKUP_REGEX, "")
+    end
+
+    def strip_title?(document)
+      if document.data.key?("strip_title")
+        document.data["strip_title"] == true
+      else
+        site.config["strip_title"] == true
+      end
+    end
+
+    def strip_title!(document)
+      matches = document.content.gsub!(TITLE_REGEX, "")
     end
 
     def filters

--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -20,6 +20,9 @@ module JekyllTitlesFromHeadings
     # (footnotes at the moment).
     EXTRA_MARKUP_REGEX = %r!\[\^[^\]]*\]!
 
+    CONFIG_KEY = "titles_from_headings".freeze
+    STRIP_TITLE_KEY = "strip_title".freeze
+
     safe true
     priority :lowest
 
@@ -70,10 +73,10 @@ module JekyllTitlesFromHeadings
     end
 
     def strip_title?(document)
-      if document.data.key?("strip_title")
-        document.data["strip_title"] == true
+      if document.data.key?(STRIP_TITLE_KEY)
+        document.data[STRIP_TITLE_KEY] == true
       else
-        site.config["strip_title"] == true
+        site.config[CONFIG_KEY] && site.config[CONFIG_KEY][STRIP_TITLE_KEY] == true
       end
     end
 

--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -78,7 +78,7 @@ module JekyllTitlesFromHeadings
     end
 
     def strip_title!(document)
-      matches = document.content.gsub!(TITLE_REGEX, "")
+      document.content.gsub!(TITLE_REGEX, "")
     end
 
     def filters

--- a/lib/jekyll-titles-from-headings/version.rb
+++ b/lib/jekyll-titles-from-headings/version.rb
@@ -1,3 +1,3 @@
 module JekyllTitlesFromHeadings
-  VERSION = "0.1.5".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/spec/fixtures/site/page-with-strip-title-false.md
+++ b/spec/fixtures/site/page-with-strip-title-false.md
@@ -1,0 +1,7 @@
+---
+strip_title: false
+---
+
+# Just an H1
+
+Blah blah blah

--- a/spec/fixtures/site/page-with-strip-title-true.md
+++ b/spec/fixtures/site/page-with-strip-title-true.md
@@ -1,0 +1,7 @@
+---
+strip_title: true
+---
+
+# Just an H1
+
+Blah blah blah

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe JekyllTitlesFromHeadings::Generator do
-  let(:site) { fixture_site("site") }
+  let(:site) { fixture_site("site", { "strip_title" => true }) }
   let(:post) { site.posts.first }
   let(:page) { page_by_path(site, "page.md") }
   let(:page_with_title) { page_by_path(site, "page-with-title.md") }
@@ -16,6 +16,8 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
   let(:page_with_no_empty_line_after_title) do
     page_by_path(site, "page-with-no-empty-line-after-title.md")
   end
+  let(:page_with_strip_title_true) { page_by_path(site, "page-with-strip-title-true.md") }
+  let(:page_with_strip_title_false) { page_by_path(site, "page-with-strip-title-false.md") }
 
   subject { described_class.new(site) }
 
@@ -112,6 +114,22 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
     end
   end
 
+  context "stripping titles" do
+    before { subject.generate(site) }
+
+    it "strips the title when enabled in the configuration" do
+      expect(page.content.strip).to eql("Blah blah blah")
+    end
+
+    it "strips the title when enabled in the front matter" do
+      expect(page_with_strip_title_true.content.strip).to eql("Blah blah blah")
+    end
+
+    it "keeps the title when disabled in the front matter" do
+      expect(page_with_strip_title_false.content.strip).to eql("# Just an H1\n\nBlah blah blah")
+    end
+  end
+
   context "generating" do
     before { subject.generate(site) }
 
@@ -119,7 +137,7 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
       expect(page.data["title"]).to eql("Just an H1")
     end
 
-    it "respect a document's auto-generated title" do
+    it "respects a document's auto-generated title" do
       expect(post.data["title"]).to eql("Test")
     end
 

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -16,8 +16,12 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
   let(:page_with_no_empty_line_after_title) do
     page_by_path(site, "page-with-no-empty-line-after-title.md")
   end
-  let(:page_with_strip_title_true) { page_by_path(site, "page-with-strip-title-true.md") }
-  let(:page_with_strip_title_false) { page_by_path(site, "page-with-strip-title-false.md") }
+  let(:page_with_strip_title_true) do
+    page_by_path(site, "page-with-strip-title-true.md")
+  end
+  let(:page_with_strip_title_false) do
+    page_by_path(site, "page-with-strip-title-false.md")
+  end
 
   subject { described_class.new(site) }
 
@@ -126,7 +130,9 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
     end
 
     it "keeps the title when disabled in the front matter" do
-      expect(page_with_strip_title_false.content.strip).to eql("# Just an H1\n\nBlah blah blah")
+      expect(page_with_strip_title_false.content.strip).to eql(
+        "# Just an H1\n\nBlah blah blah"
+      )
     end
   end
 

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe JekyllTitlesFromHeadings::Generator do
-  let(:site) { fixture_site("site", { "strip_title" => true }) }
+  let(:site) do
+    fixture_site("site", { "titles_from_headings" => { "strip_title" => true } })
+  end
   let(:post) { site.posts.first }
   let(:page) { page_by_path(site, "page.md") }
   let(:page_with_title) { page_by_path(site, "page-with-title.md") }

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe JekyllTitlesFromHeadings::Generator do
-  let(:site) do
-    fixture_site("site", { "titles_from_headings" => { "strip_title" => true } })
-  end
+  let(:config) { {} }
+  let(:site) { fixture_site("site", config) }
   let(:post) { site.posts.first }
   let(:page) { page_by_path(site, "page.md") }
   let(:page_with_title) { page_by_path(site, "page-with-title.md") }
@@ -123,8 +122,18 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
   context "stripping titles" do
     before { subject.generate(site) }
 
-    it "strips the title when enabled in the configuration" do
-      expect(page.content.strip).to eql("Blah blah blah")
+    context "a site with strip title enabled globally" do
+      let(:config) { { "titles_from_headings" => { "strip_title" => true } } }
+
+      it "strips the title when enabled in the configuration" do
+        expect(page.content.strip).to eql("Blah blah blah")
+      end
+
+      it "keeps the title when disabled in the front matter" do
+        expect(page_with_strip_title_false.content.strip).to eql(
+          "# Just an H1\n\nBlah blah blah"
+        )
+      end
     end
 
     it "strips the title when enabled in the front matter" do


### PR DESCRIPTION
Hi, as discussed in #10, I've added an opt-in option to strip titles on a global and per-page basis.
Obviously I can resubmit if you're unhappy with the generic `strip_title` name.

I've also updated the README and added basic tests.