### PR TITLE
Add support for collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ defaults:
 
 ### Processing Collections
 
-If you want to enable this plugin for collection items set `collections` to a truthy value. Since collection items (including posts) already have their title inferred from the filename, this option changes the behavior of this plugin to override the inferred title and use it as a fallback if the document doesn't start with a heading.
+If you want to enable this plugin for collection items, set the `collections` option to `true`.
+
+Since collection items (including posts) already have a title inferred from their filename, this option changes the behavior of this plugin to override the inferred title. The inferred title is only used as a fallback in case the document doesn't start with a heading.
 
 ### Disabling
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Configuration options are optional and placed in `_config.yml` under the `titles
 
 ```yml
 titles_from_headings:
+  enabled:     true
   strip_title: false
   collections: false
-  disabled:    false
 ```
 
 ### Stripping titles
@@ -63,4 +63,4 @@ If you want to enable this plugin for collection items set `collections` to a tr
 
 ### Disabling
 
-Even if the plugin is enabled (e.g., via the `:jekyll_plugins` group in your Gemfile) you can disable it by setting the `disabled` key to a truthy value.
+Even if the plugin is enabled (e.g., via the `:jekyll_plugins` group in your Gemfile) you can disable it by setting the `enabled` key to `false`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *A Jekyll plugin to pull the page title from the first Markdown heading when none is specified.*
 
-[![Build Status](https://travis-ci.org/benbalter/jekyll-title-from-headings.svg?branch=master)](https://travis-ci.org/benbalter/jekyll-title-from-headings)
+[![Build Status](https://travis-ci.org/benbalter/jekyll-titles-from-headings.svg?branch=master)](https://travis-ci.org/benbalter/jekyll-titles-from-headings)
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,19 @@ Additionally, this allows you to store the title semantically, in the document i
   ```
 
 ## Configuration
-If your theme renders titles based on `page.title`, you can remove the title from the content by setting
+
+Configuration options are optional and placed in `_config.yml` under the `titles_from_headings` key. They default to:
 
 ```yml
 titles_from_headings:
-  strip_title: true
+  strip_title: false
+  collections: false
+  disabled:    false
 ```
 
-in your site's `_config.yml` to prevent rendering the title twice.
+### Stripping titles
+
+If your theme renders titles based on `page.title`, you can remove the title from the content by setting `strip_title` to prevent rendering it twice.
 
 To limit this behavior to a certain layouts or paths, you can use [front matter defaults](https://jekyllrb.com/docs/configuration/#front-matter-defaults), e.g.
 
@@ -48,9 +53,14 @@ defaults:
   - scope:
       path: some-path
       layout: some_layout
-      type: posts # pages, posts, drafts or any collection in your site.
     values:
       strip_title: true
 ```
 
-Note that you need [`jekyll-optional-front-matter`](https://github.com/benbalter/jekyll-optional-front-matter) for this to work on pages without a front matter.
+### Processing Collections
+
+If you want to enable this plugin for collection items set `collections` to a truthy value. Since collection items (including posts) already have their title inferred from the filename, this option changes the behavior of this plugin to override the inferred title and use it as a fallback if the document doesn't start with a heading.
+
+### Disabling
+
+Even if the plugin is enabled (e.g., via the `:jekyll_plugins` group in your Gemfile) you can disable it by setting the `disabled` key to a truthy value.

--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -36,10 +36,10 @@ module JekyllTitlesFromHeadings
       @site = site
       return if disabled?
 
-      pages = site.pages
-      pages = site.pages + site.documents if collections?
+      documents = site.pages
+      documents = site.pages + site.docs_to_write if collections?
 
-      pages.each do |document|
+      documents.each do |document|
         next unless should_add_title?(document)
         document.data["title"] = title_for(document)
         strip_title!(document) if strip_title?(document)

--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -21,7 +21,7 @@ module JekyllTitlesFromHeadings
     EXTRA_MARKUP_REGEX = %r!\[\^[^\]]*\]!
 
     CONFIG_KEY = "titles_from_headings".freeze
-    DISABLED_KEY = "disabled".freeze
+    ENABLED_KEY = "enabled".freeze
     STRIP_TITLE_KEY = "strip_title".freeze
     COLLECTIONS_KEY = "collections".freeze
 
@@ -84,7 +84,7 @@ module JekyllTitlesFromHeadings
     end
 
     def disabled?
-      option(DISABLED_KEY)
+      option(ENABLED_KEY) == false
     end
 
     def strip_title?(document)

--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -21,6 +21,7 @@ module JekyllTitlesFromHeadings
     EXTRA_MARKUP_REGEX = %r!\[\^[^\]]*\]!
 
     CONFIG_KEY = "titles_from_headings".freeze
+    DISABLED_KEY = "disabled".freeze
     STRIP_TITLE_KEY = "strip_title".freeze
     COLLECTIONS_KEY = "collections".freeze
 
@@ -33,6 +34,7 @@ module JekyllTitlesFromHeadings
 
     def generate(site)
       @site = site
+      return if disabled?
 
       pages = site.pages
       pages = site.pages + site.documents if collections?
@@ -77,16 +79,24 @@ module JekyllTitlesFromHeadings
       end.gsub(EXTRA_MARKUP_REGEX, "")
     end
 
+    def option(key)
+      site.config[CONFIG_KEY] && site.config[CONFIG_KEY][key]
+    end
+
+    def disabled?
+      option(DISABLED_KEY)
+    end
+
     def strip_title?(document)
       if document.data.key?(STRIP_TITLE_KEY)
-        document.data[STRIP_TITLE_KEY] == true
+        document.data[STRIP_TITLE_KEY]
       else
-        site.config[CONFIG_KEY] && site.config[CONFIG_KEY][STRIP_TITLE_KEY] == true
+        option(STRIP_TITLE_KEY)
       end
     end
 
     def collections?
-      site.config[CONFIG_KEY] && site.config[CONFIG_KEY][COLLECTIONS_KEY] == true
+      option(COLLECTIONS_KEY)
     end
 
     # Documents (posts and collection items) have their title inferred from the filename.

--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -89,14 +89,14 @@ module JekyllTitlesFromHeadings
 
     def strip_title?(document)
       if document.data.key?(STRIP_TITLE_KEY)
-        document.data[STRIP_TITLE_KEY]
+        document.data[STRIP_TITLE_KEY] == true
       else
-        option(STRIP_TITLE_KEY)
+        option(STRIP_TITLE_KEY) == true
       end
     end
 
     def collections?
-      option(COLLECTIONS_KEY)
+      option(COLLECTIONS_KEY) == true
     end
 
     # Documents (posts and collection items) have their title inferred from the filename.

--- a/spec/fixtures/site/_items/some-item.md
+++ b/spec/fixtures/site/_items/some-item.md
@@ -1,6 +1,6 @@
 ---
 ---
 
-# Some post
+# Some item
 
 Blah blah blah

--- a/spec/fixtures/site/_posts/2016-01-01-test-2.md
+++ b/spec/fixtures/site/_posts/2016-01-01-test-2.md
@@ -1,6 +1,4 @@
 ---
 ---
 
-# Some post
-
 Blah blah blah

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -216,4 +216,22 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
       end
     end
   end
+
+  context "when disabled" do
+    let(:overrides) { { "titles_from_headings" => { "disabled" => true } } }
+
+    it "sets titles for pages" do
+      subject.generate(site)
+      expect(page.data["title"]).to_not eql("Just an H1")
+    end
+  end
+
+  context "when explicitly enabled" do
+    let(:overrides) { { "titles_from_headings" => { "disabled" => false } } }
+
+    it "sets titles for pages" do
+      subject.generate(site)
+      expect(page.data["title"]).to eql("Just an H1")
+    end
+  end
 end

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
   end
 
   context "when disabled" do
-    let(:overrides) { { "titles_from_headings" => { "disabled" => true } } }
+    let(:config) { { "titles_from_headings" => { "disabled" => true } } }
 
     it "sets titles for pages" do
       subject.generate(site)
@@ -227,7 +227,7 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
   end
 
   context "when explicitly enabled" do
-    let(:overrides) { { "titles_from_headings" => { "disabled" => false } } }
+    let(:config) { { "titles_from_headings" => { "disabled" => false } } }
 
     it "sets titles for pages" do
       subject.generate(site)

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -119,34 +119,6 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
     end
   end
 
-  context "stripping titles" do
-    before { subject.generate(site) }
-
-    context "a site with strip title enabled globally" do
-      let(:config) { { "titles_from_headings" => { "strip_title" => true } } }
-
-      it "strips the title when enabled in the configuration" do
-        expect(page.content.strip).to eql("Blah blah blah")
-      end
-
-      it "keeps the title when disabled in the front matter" do
-        expect(page_with_strip_title_false.content.strip).to eql(
-          "# Just an H1\n\nBlah blah blah"
-        )
-      end
-    end
-
-    it "strips the title when enabled in the front matter" do
-      expect(page_with_strip_title_true.content.strip).to eql("Blah blah blah")
-    end
-
-    it "keeps the title when disabled in the front matter" do
-      expect(page_with_strip_title_false.content.strip).to eql(
-        "# Just an H1\n\nBlah blah blah"
-      )
-    end
-  end
-
   context "generating" do
     before { subject.generate(site) }
 
@@ -160,6 +132,44 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
 
     it "respects a document's YAML title" do
       expect(page_with_title.data["title"]).to eql("Page with title")
+    end
+
+    it "does not strip the title when not enabled in the configuration" do
+      expect(page.content.strip).to eql("# Just an H1\n\nBlah blah blah")
+    end
+
+    context "stripping titles" do
+      context "a site with strip title enabled globally" do
+        let(:config) { { "titles_from_headings" => { "strip_title" => true } } }
+
+        it "strips the title when enabled in the configuration" do
+          expect(page.content.strip).to eql("Blah blah blah")
+        end
+
+        it "keeps the title when disabled in the front matter" do
+          expect(page_with_strip_title_false.content.strip).to eql(
+            "# Just an H1\n\nBlah blah blah"
+          )
+        end
+      end
+
+      it "strips the title when enabled in the front matter" do
+        expect(page_with_strip_title_true.content.strip).to eql("Blah blah blah")
+      end
+
+      it "keeps the title when disabled in the front matter" do
+        expect(page_with_strip_title_false.content.strip).to eql(
+          "# Just an H1\n\nBlah blah blah"
+        )
+      end
+    end
+
+
+
+
+
+    end
+
     end
   end
 end

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
   end
 
   context "when disabled" do
-    let(:config) { { "titles_from_headings" => { "disabled" => true } } }
+    let(:config) { { "titles_from_headings" => { "enabled" => false } } }
 
     it "sets titles for pages" do
       subject.generate(site)
@@ -227,7 +227,7 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
   end
 
   context "when explicitly enabled" do
-    let(:config) { { "titles_from_headings" => { "disabled" => false } } }
+    let(:config) { { "titles_from_headings" => { "enabled" => true } } }
 
     it "sets titles for pages" do
       subject.generate(site)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,3 +33,7 @@ end
 def page_by_path(site, path)
   site.pages.find { |p| p.path == path }
 end
+
+def doc_by_path(site, path)
+  site.documents.find { |p| p.relative_path == path }
+end


### PR DESCRIPTION
This implements #5. It also adds an option to disable the plugin, similar to benbalter/jekyll-optional-front-matter#9.

It includes updated documentation and tests.

Some tests have been rearranged which created a bit of a mess (`stripping titles` is now under the `generating` context).

And it also fixes to link to the build status icon :)