### PR TITLE
Fix 26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.gem
 Gemfile.lock
 spec/examples.txt
+vendor/bundle
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/jekyll-titles-from-headings.gemspec
+++ b/jekyll-titles-from-headings.gemspec
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "jekyll-titles-from-headings/version"
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
 
   s.add_dependency "jekyll", "~> 3.3"
-  s.add_development_dependency "rubocop", "~> 0.43"
   s.add_development_dependency "rspec", "~> 3.5"
+  s.add_development_dependency "rubocop", "~> 0.43"
 end

--- a/lib/jekyll-titles-from-headings.rb
+++ b/lib/jekyll-titles-from-headings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "jekyll"
 require "jekyll-titles-from-headings/generator"
 

--- a/lib/jekyll-titles-from-headings/context.rb
+++ b/lib/jekyll-titles-from-headings/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllTitlesFromHeadings
   class Context
     attr_reader :site

--- a/lib/jekyll-titles-from-headings/filters.rb
+++ b/lib/jekyll-titles-from-headings/filters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllTitlesFromHeadings
   class Filters
     include Jekyll::Filters

--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -41,6 +41,7 @@ module JekyllTitlesFromHeadings
 
       documents.each do |document|
         next unless should_add_title?(document)
+        next if document.is_a?(Jekyll::StaticFile)
         document.data["title"] = title_for(document)
         strip_title!(document) if strip_title?(document)
       end

--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 module JekyllTitlesFromHeadings
   class Generator < Jekyll::Generator
     attr_accessor :site
 
+    # rubocop:disable Lint/InterpolationCheck
     TITLE_REGEX =
       %r!
         \A\s*                   # Beginning and whitespace
@@ -11,6 +14,7 @@ module JekyllTitlesFromHeadings
             (.*)\r?\n[-=]+\s*   # Setex-style header
           )$                    # end of line
       !x
+    # rubocop:enable Lint/InterpolationCheck
     CONVERTER_CLASS = Jekyll::Converters::Markdown
     STRIP_MARKUP_FILTERS = %i[
       markdownify strip_html normalize_whitespace

--- a/lib/jekyll-titles-from-headings/version.rb
+++ b/lib/jekyll-titles-from-headings/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllTitlesFromHeadings
   VERSION = "0.5.0".freeze
 end

--- a/spec/fixtures/site/_items/static-file.md
+++ b/spec/fixtures/site/_items/static-file.md
@@ -1,0 +1,1 @@
+Static file

--- a/spec/jekyll-titles-from-headings/context_spec.rb
+++ b/spec/jekyll-titles-from-headings/context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe JekyllTitlesFromHeadings::Context do
   let(:site) { fixture_site("site") }
   subject { described_class.new(site) }

--- a/spec/jekyll-titles-from-headings/filters_spec.rb
+++ b/spec/jekyll-titles-from-headings/filters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe JekyllTitlesFromHeadings::Filters do
   let(:site) { fixture_site("site") }
   subject { described_class.new(site) }

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe JekyllTitlesFromHeadings::Generator do
   let(:config) { {} }
   let(:site) { fixture_site("site", config) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "jekyll-titles-from-headings"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Basically just applying the same changes as https://github.com/benbalter/jekyll-relative-links/commit/137f4b881cae72a02f9066f8cd06c5819594c69d.

Most of the changes are to satisfy the new rubocop config.