### PR TITLE
Fix error when stripping title from a page with frozen content

### DIFF
--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -118,8 +118,7 @@ module JekyllTitlesFromHeadings
 
     def strip_title!(document)
       if document.content
-        document.content.gsub!(TITLE_REGEX, "")
-        document.content.strip!
+        document.content = document.content.gsub(TITLE_REGEX, "").strip
         strip_title_excerpt!(document) if strip_title_excerpt?(document)
       end
     end

--- a/spec/jekyll-titles-from-headings/generator_spec.rb
+++ b/spec/jekyll-titles-from-headings/generator_spec.rb
@@ -249,4 +249,10 @@ RSpec.describe JekyllTitlesFromHeadings::Generator do
       expect(page.data["title"]).to eql("Just an H1")
     end
   end
+
+  it "doesn't error when stripping title from a page with frozen content" do
+    page_with_strip_title_true.content = "".freeze
+    subject.generate(site)
+    expect(page_with_strip_title_true.data["title"]).to be_nil
+  end
 end


### PR DESCRIPTION
`document.content` could be a frozen empty string if it was set by the jekyll-redirect-from gem. Because frozen strings everywhere is where everything is headed, and this gem relies on strings defined in other gems, it seemed safest to fix here.

(https://github.com/jekyll/jekyll-redirect-from/blob/v0.13.0/lib/jekyll-redirect-from/redirect_page.rb#L37 is where the frozen string comes from)
