### PR TITLE
Add case for hashes at the end of lines

### DIFF
--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -5,12 +5,12 @@ module JekyllTitlesFromHeadings
     attr_accessor :site
     TITLE_REGEX =
       %r!
-        \A\s*                   # Beginning and whitespace
-          (?:                   # either
-            \#{1,3}\s+(.*)      # atx-style header
-            |                   # or
-            (.*)\r?\n[-=]+\s*   # Setex-style header
-          )$                    # end of line
+        \A\s*                             # Beginning and whitespace
+          (?:                             # either
+            \#{1,3}\s+(.*)(?:\s+\#{1,3})? # atx-style header
+            |                             # or
+            (.*)\r?\n[-=]+\s*             # Setex-style header
+          )$                              # end of line
       !x
 
     CONVERTER_CLASS = Jekyll::Converters::Markdown


### PR DESCRIPTION
Just adds an optional bit to the end of the regex to catch and discard hashes at the end.

Should fix #36.