### PR TITLE
Simplify excerpt condition

### DIFF
--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -99,12 +99,6 @@ module JekyllTitlesFromHeadings
       end
     end
 
-    def strip_title_excerpt?(document)
-      document.is_a?(Jekyll::Document) &&
-        document.collection.label == "posts" &&
-        document.generate_excerpt?
-    end
-
     def collections?
       option(COLLECTIONS_KEY) == true
     end
@@ -118,12 +112,12 @@ module JekyllTitlesFromHeadings
     def strip_title!(document)
       if document.content
         document.content = document.content.gsub(TITLE_REGEX, "").strip
-        strip_title_excerpt!(document) if strip_title_excerpt?(document)
+        strip_title_excerpt!(document)
       end
     end
 
     def strip_title_excerpt!(document)
-      document.data["excerpt"] = Jekyll::Excerpt.new(document) if document.generate_excerpt?
+      document.data["excerpt"] = Jekyll::Excerpt.new(document) if document.data["excerpt"]
     end
 
     def filters


### PR DESCRIPTION
Currently, we are checking the document type for "posts" and then call `generate_excerpt?` to determine if the excerpt should be updated.

It's much better to just check for the presence of `data["excerpt"]` and update it if it is available.

This should also allow this plugin to work with page excerpts introduced in Jekeyll 4.

Finally, this brings the excerpt logic in line with https://github.com/benbalter/jekyll-relative-links/pull/65