### PR TITLE
Remove check for collection type from the strip_title_exerpt? function

### DIFF
--- a/lib/jekyll-titles-from-headings/generator.rb
+++ b/lib/jekyll-titles-from-headings/generator.rb
@@ -102,7 +102,6 @@ module JekyllTitlesFromHeadings
 
     def strip_title_excerpt?(document)
       document.is_a?(Jekyll::Document) &&
-        document.collection.label == "posts" &&
         document.generate_excerpt?
     end
 


### PR DESCRIPTION
Remove the check for collection type when determining whether to strip the title from the excerpt. Fixes #81 

I'm not super familiar with Jekyll so not sure if this will have any unintended side effects. It seemed to work fine in my testing though.