### PR TITLE
Release v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 0.5.4
+
+### Bug fixes
+
+- Only strip the title from a document's excerpt when that document actually
+  generates an excerpt, avoiding needless excerpt creation (#63)
+
+### Infrastructure
+
+- Modernize CI — test Ruby 3.3 & 4.0 against Jekyll 3.x & 4.x, and fix the
+  build under rubocop-rspec 3.0 (#87)
+- Bump rubocop-rspec to `~> 3.0` (#83)
+- Enable Dependabot for GitHub Actions; bump `actions/checkout` and
+  `github/codeql-action` (#84, #85, #86)
+- Add `kramdown-parser-gfm` as a dev dependency
+- Add CodeQL analysis workflow

--- a/lib/jekyll-titles-from-headings/version.rb
+++ b/lib/jekyll-titles-from-headings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllTitlesFromHeadings
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
 end


### PR DESCRIPTION
Prepares **v0.5.4** (patch). Adds a `CHANGELOG.md` (none existed). Publish is a manual `gem push` after merge.

**Bump:** 0.5.3 → 0.5.4

### Changelog
**Bug fixes**
- Only strip the title from a document's excerpt when it actually generates one (#63)

**Infrastructure**
- Modernize CI — Ruby 3.3 & 4.0 × Jekyll 3.x & 4.x; fix build under rubocop-rspec 3.0 (#87)
- Bump rubocop-rspec to `~> 3.0` (#83)
- Enable Dependabot for GitHub Actions; bump `actions/checkout` and `github/codeql-action` (#84, #85, #86)
- Add `kramdown-parser-gfm` dev dep; add CodeQL workflow

_Patch: one bug fix + maintenance._

🤖 Generated with [Claude Code](https://claude.com/claude-code)